### PR TITLE
Added PlayerHook, Expanded Effect capabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.github.maxopoly</groupId>
 	<artifactId>WurstCivTools</artifactId>
-	<version>1.1.5</version>
+	<version>1.2.0</version>
 	<packaging>jar</packaging>
 	<url>https://github.com/Civcraft/WurstCivTools</url>
 

--- a/src/main/java/com/github/maxopoly/WurstCivTools/ConfigParser.java
+++ b/src/main/java/com/github/maxopoly/WurstCivTools/ConfigParser.java
@@ -1,24 +1,21 @@
 package com.github.maxopoly.WurstCivTools;
 
-import static vg.civcraft.mc.civmodcore.util.ConfigParsing.parseItemMap;
 import static vg.civcraft.mc.civmodcore.util.ConfigParsing.parseItemMapDirectly;
 import static vg.civcraft.mc.civmodcore.util.ConfigParsing.parseTime;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
-
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.enchantments.Enchantment;
 
-import vg.civcraft.mc.civmodcore.Config;
 import vg.civcraft.mc.civmodcore.itemHandling.ItemMap;
 
 import com.github.maxopoly.WurstCivTools.anvil.AnvilHandler;
+import com.github.maxopoly.WurstCivTools.effect.PlayerHook;
 import com.github.maxopoly.WurstCivTools.effect.PylonFinder;
 import com.github.maxopoly.WurstCivTools.effect.WurstEffect;
 import com.github.maxopoly.WurstCivTools.tags.LoreTag;
@@ -57,6 +54,10 @@ public class ConfigParser {
 			WurstEffect effect;
 			switch (type) {
 			case "PYLONFINDER":
+				if (current.getBoolean("enabled",false) == false){
+					plugin.info("Pylonfinder disabled, skipping...");
+					continue;
+				}
 				if (!Bukkit.getPluginManager().isPluginEnabled("FactoryMod")) {
 					plugin.severe("Attempted to load Pylonfinder tool, but FactoryMod is not installed on this server");
 					continue;
@@ -71,6 +72,22 @@ public class ConfigParser {
 						+ showNonRunning + ", showUpgrading:" + showUpgrading
 						+ ", cooldown:" + cd);
 				break;
+			case "PLAYERHOOK":
+				if (current.getBoolean("enabled",false) == false){
+					plugin.info("PlayerHook disabled, skipping...");
+					continue;
+				}
+				boolean prevent_swords = current.getBoolean("prevent_use_with_swords", false);
+				boolean prevent_axes = current.getBoolean("prevent_use_with_axes", false);
+				boolean prevent_bows = current.getBoolean("prevent_use_with_bows", false);
+				int stop_count = current.getInt("hooks_to_stop_movement", 2); if(stop_count<=0){stop_count=2;}
+				double speed_change = current.getDouble("hook_speed_change",-0.05D);
+				effect = new PlayerHook(prevent_swords,prevent_axes,prevent_bows,stop_count, speed_change);
+				plugin.info("Parsed PlayerHook tool, swords:" + prevent_swords +
+						", axes:" + prevent_axes + ", bows:" + prevent_bows + 
+						", stop_count:" + stop_count + ", speed_change:" +speed_change);
+				break;
+
 			default:
 				plugin.severe("Could not identify effect type " + type + " at "
 						+ config.getCurrentPath());

--- a/src/main/java/com/github/maxopoly/WurstCivTools/WurstCivTools.java
+++ b/src/main/java/com/github/maxopoly/WurstCivTools/WurstCivTools.java
@@ -1,10 +1,14 @@
 package com.github.maxopoly.WurstCivTools;
 
+import java.util.List;
+
 import org.bukkit.Bukkit;
+import org.bukkit.event.Listener;
 
 import com.github.maxopoly.WurstCivTools.anvil.AnvilHandler;
 import com.github.maxopoly.WurstCivTools.listener.AnvilListener;
 import com.github.maxopoly.WurstCivTools.listener.ToolListener;
+import com.github.maxopoly.WurstCivTools.tags.Tag;
 
 import vg.civcraft.mc.civmodcore.ACivMod;
 
@@ -46,6 +50,14 @@ public class WurstCivTools extends ACivMod {
 		Bukkit.getPluginManager().registerEvents(new ToolListener(), this);
 		if (anvilHandler != null) {
 			Bukkit.getPluginManager().registerEvents(new AnvilListener(anvilHandler), this);
+		}
+		for(List<Tag> tags : manager.getAllTags()){
+			for (Tag tag : tags){
+				Listener l = tag.getEffect().getListener();
+				if (l != null){
+					Bukkit.getPluginManager().registerEvents(l, this);
+				}
+			}
 		}
 	}
 }

--- a/src/main/java/com/github/maxopoly/WurstCivTools/WurstManager.java
+++ b/src/main/java/com/github/maxopoly/WurstCivTools/WurstManager.java
@@ -1,13 +1,14 @@
 package com.github.maxopoly.WurstCivTools;
 
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 
+import com.github.maxopoly.WurstCivTools.effect.WurstEffect;
 import com.github.maxopoly.WurstCivTools.tags.Tag;
 
 public class WurstManager {
@@ -30,5 +31,20 @@ public class WurstManager {
 			tags.put(tag.getMaterial(), existing);
 		}
 		existing.add(tag);
+	}
+	
+	public Collection<List<Tag>> getAllTags(){
+		return tags.values();
+	}
+
+	public Tag getEffectTag(WurstEffect effect) {
+		for(List<Tag> taglist : tags.values()){
+			for(Tag tag : taglist){
+				if (tag.getEffect().equals(effect)){
+					return tag;
+				}
+			}
+		}
+		return null;
 	}
 }

--- a/src/main/java/com/github/maxopoly/WurstCivTools/effect/PlayerHook.java
+++ b/src/main/java/com/github/maxopoly/WurstCivTools/effect/PlayerHook.java
@@ -1,0 +1,120 @@
+package com.github.maxopoly.WurstCivTools.effect;
+
+import java.util.Map.Entry;
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerItemHeldEvent;
+import org.bukkit.event.player.PlayerSwapHandItemsEvent;
+import org.bukkit.inventory.Inventory;
+
+import com.github.maxopoly.WurstCivTools.listener.PlayerHookListener;
+import com.github.maxopoly.WurstCivTools.misc.HookData;
+
+public class PlayerHook extends WurstEffect {
+	private PlayerHookListener listener;
+	public final boolean swords;
+	public final boolean axes;
+	public final boolean bows;
+	public final int stopcount;
+	public final double speed_change;
+	
+
+	public PlayerHook(boolean prevent_swords, boolean prevent_axes, 
+			boolean prevent_bows, int stop_count, double speed_change) {
+		this.swords = prevent_swords;
+		this.axes = prevent_axes;
+		this.bows = prevent_bows;
+		this.stopcount = stop_count;
+		this.speed_change = speed_change;
+	}
+	
+	@Override
+	public Listener getListener(){
+		this.listener = new PlayerHookListener(this);
+		return this.listener;
+	}
+	
+	@Override 
+	public void handleItemSelect(Player p, PlayerItemHeldEvent e){
+		if (canSelect(p) == false)
+			e.setCancelled(true);
+	}
+
+	@Override
+	public void handleItemDeselect(Player p, PlayerItemHeldEvent e) {
+		clearHooks(p.getUniqueId());
+	}
+	
+	@Override
+	public void handleSwapToMainHand(Player p, PlayerSwapHandItemsEvent e) {
+		if (canSelect(p) == false)
+			e.setCancelled(true);
+	}
+
+	@Override
+	public void handleSwapToOffHand(Player p, PlayerSwapHandItemsEvent e) {
+		clearHooks(p.getUniqueId());
+	}
+
+	private boolean canSelect(Player p){
+		if (swords){
+			Inventory inv = p.getInventory();
+			if (inv.contains(Material.DIAMOND_SWORD)){
+				p.sendMessage("You cannot use this item with a Sword in your inventory.");
+				return false;
+			} else if (inv.contains(Material.IRON_SWORD)){
+				p.sendMessage("You cannot use this item with a Sword in your inventory.");
+				return false;
+			} else if (inv.contains(Material.STONE_SWORD)){
+				p.sendMessage("You cannot use this item with a Sword in your inventory.");
+				return false;
+			} else if (inv.contains(Material.WOOD_SWORD)){
+				p.sendMessage("You cannot use this item with a Sword in your inventory.");
+				return false;
+			} else if (inv.contains(Material.GOLD_SWORD)){
+				p.sendMessage("You cannot use this item with a Sword in your inventory.");
+				return false;
+			}
+		} 
+		if (axes){
+			Inventory inv = p.getInventory();
+			if (inv.contains(Material.GOLD_AXE)){
+				p.sendMessage("You cannot use this item with an Axe in your inventory.");
+				return false;
+			} else if (inv.contains(Material.DIAMOND_AXE)){
+				p.sendMessage("You cannot use this item with an Axe in your inventory.");
+				return false;
+			} else if (inv.contains(Material.IRON_AXE)){
+				p.sendMessage("You cannot use this item with an Axe in your inventory.");
+				return false;
+			} else if (inv.contains(Material.STONE_AXE)){
+				p.sendMessage("You cannot use this item with an Axe in your inventory.");
+				return false;
+			} else if (inv.contains(Material.WOOD_AXE)){
+				p.sendMessage("You cannot use this item with an Axe in your inventory.");
+				return false;
+			}
+		} 
+		if (bows){
+			if (p.getInventory().contains(Material.BOW)){
+				p.sendMessage("You cannot use this item with a Bow in your inventory.");
+				return false;
+			}
+		}
+		return true;
+	}
+	
+	private void clearHooks(UUID uuid){
+		for(Entry<UUID, HookData> hook : listener.getHooks().entrySet()){
+			if (uuid.equals(hook.getValue().getSource())){
+				listener.removehook(hook.getKey());
+				break;
+			}
+		}
+	}
+	
+}

--- a/src/main/java/com/github/maxopoly/WurstCivTools/effect/WurstEffect.java
+++ b/src/main/java/com/github/maxopoly/WurstCivTools/effect/WurstEffect.java
@@ -1,11 +1,19 @@
 package com.github.maxopoly.WurstCivTools.effect;
 
 import org.bukkit.entity.Player;
+import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.player.PlayerChangedMainHandEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerItemHeldEvent;
+import org.bukkit.event.player.PlayerSwapHandItemsEvent;
 
 public abstract class WurstEffect {
+	
+	public Listener getListener(){
+		return null;
+	}
 	
 	public void handleDamageEntity(Player p, EntityDamageByEntityEvent e) {
 		
@@ -18,4 +26,21 @@ public abstract class WurstEffect {
 	public void handleInteract(Player p, PlayerInteractEvent e) {
 		
 	}
+	
+	public void handleItemSelect(Player p, PlayerItemHeldEvent e){
+		
+	}
+	
+	public void handleItemDeselect(Player p, PlayerItemHeldEvent e){
+		
+	}
+	
+	public void handleSwapToMainHand(Player p, PlayerSwapHandItemsEvent e){
+		
+	}
+	
+	public void handleSwapToOffHand(Player p, PlayerSwapHandItemsEvent e){
+		
+	}
+	
 }

--- a/src/main/java/com/github/maxopoly/WurstCivTools/listener/PlayerHookListener.java
+++ b/src/main/java/com/github/maxopoly/WurstCivTools/listener/PlayerHookListener.java
@@ -1,0 +1,203 @@
+package com.github.maxopoly.WurstCivTools.listener;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.ProjectileHitEvent;
+import org.bukkit.event.entity.ProjectileLaunchEvent;
+import org.bukkit.event.player.PlayerFishEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.inventory.ItemStack;
+import com.github.maxopoly.WurstCivTools.WurstCivTools;
+import com.github.maxopoly.WurstCivTools.effect.PlayerHook;
+import com.github.maxopoly.WurstCivTools.misc.HookData;
+import com.github.maxopoly.WurstCivTools.tags.Tag;
+
+public class PlayerHookListener implements Listener{
+	private final PlayerHook effect;
+	private final Tag tag;
+	private final HashMap<UUID, HookData> hooks = new HashMap<UUID, HookData>();
+	private final UUID emptyid = UUID.fromString("00000000-0000-0000-0000-000000000000");
+	private final HashSet<UUID> held = new HashSet<UUID>();
+	
+
+	public PlayerHookListener(PlayerHook playerHook) {
+		this.effect = playerHook;
+		this.tag = WurstCivTools.getManager().getEffectTag(this.effect);
+	}
+	
+	public HashMap<UUID,HookData> getHooks(){
+		return hooks;
+	}
+	
+	@EventHandler(ignoreCancelled = true)
+	public void fishEvent(PlayerFishEvent e){
+		ItemStack is = e.getPlayer().getItemInHand();
+		if (is == null)
+			return;
+		if (!tag.appliedOn(is))
+			return;
+		
+		UUID hook = e.getHook().getUniqueId();
+		switch (e.getState()){
+		case FISHING:
+			addhook(hook, e.getPlayer().getUniqueId());
+			break;
+		
+		case CAUGHT_ENTITY:
+			removehook(hook);
+			break;
+			
+		default:
+			removehook(hook);
+			break;
+		}
+	}
+	
+	@EventHandler(ignoreCancelled = true)
+	public void pearlThrow(ProjectileLaunchEvent e){
+		if (!e.getEntityType().equals(EntityType.ENDER_PEARL))
+			return;
+		if (!(e.getEntity().getShooter() instanceof Player))
+			return;
+		
+		Player p = (Player) e.getEntity().getShooter();
+		UUID uuid = p.getUniqueId();
+		for(HookData hook : hooks.values()){
+			if (hook.getTarget().equals(uuid)){
+				e.setCancelled(true);
+				p.getInventory().addItem(new ItemStack(Material.ENDER_PEARL, 1));
+				break;
+			}
+		}
+	}
+	
+	
+	@EventHandler(ignoreCancelled = true)
+	public void hookGrab(ProjectileHitEvent e){
+		Entity entity = e.getEntity();
+		if (!e.getEntityType().equals(EntityType.FISHING_HOOK))
+			return;
+		HookData hook = hooks.get(entity.getUniqueId());
+		if (hook == null || hook.getTarget().equals(emptyid) == false)
+			return;
+		List<Entity> nearby = entity.getNearbyEntities(0, 0, 0);
+		for(Entity ent : nearby){
+			if (!(ent instanceof Player) || ent.getUniqueId().equals(hook.getSource()))
+				continue;
+			applyhook((Player)ent, hook);
+			return;
+		}
+		
+		// Delayed detection of entity hooked. Provides better accuracy, as ProjectileHitEvent
+		//  doesn't provide any instance of block or entity hit, only projectile entity.
+		// Will only happen if initial detection does not succeed
+		Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(WurstCivTools.getPlugin(), new Runnable(){
+			@Override
+			public void run() {
+				List<Entity> nearby = entity.getNearbyEntities(0, 1, 0);
+				for(Entity ent : nearby){
+					if (!(ent instanceof Player) || ent.getUniqueId().equals(hook.getSource()))
+						continue;
+					applyhook((Player)ent, hook);
+					break;
+				}
+			}
+			
+		}, 1);
+	}
+	
+	@EventHandler(ignoreCancelled = true)
+	public void playerMove(PlayerMoveEvent e){
+		if (held.isEmpty() || held.contains(e.getPlayer().getUniqueId()) == false)
+			return;
+		
+		Location from = e.getFrom(); Location to = e.getTo();
+		if (from.getX()!=to.getX() || from.getY()!=to.getY() || from.getZ()!=to.getZ()){
+			e.setCancelled(true);
+		}
+	}
+	
+	@EventHandler(ignoreCancelled = true)
+	public void playerLogout(PlayerQuitEvent e){
+		UUID uuid = e.getPlayer().getUniqueId();
+		for (Entry<UUID, HookData> hook : hooks.entrySet()){
+			HookData dat = hook.getValue();
+			if (dat.getSource().equals(uuid) || dat.getTarget().equals(uuid)){
+				removehook(hook.getKey());
+			}
+		}
+	}
+	
+	public void removehook(UUID hookid){
+		HookData dat = hooks.get(hookid); if (dat==null)return;
+		if (!dat.getTarget().equals(emptyid)){
+			int count = 0;
+			for(HookData hook : hooks.values()){
+				if (dat.getTarget().equals(hook.getTarget()))
+					count++;
+			}
+			count--;
+			Player p = Bukkit.getPlayer(dat.getTarget());
+			if (p != null){
+				setspeed(p,count);
+			}
+		}
+		hooks.remove(hookid);
+	}
+	
+	private void addhook(UUID hook, UUID source){
+		hooks.put(hook, new HookData(source, emptyid));
+	}
+	
+	private void applyhook(Player player, HookData hook){
+		UUID uuid = player.getUniqueId();
+		hook.setTarget(uuid);
+		int count = 0;
+		for(Entry<UUID,HookData> hooks : getHooks().entrySet()){
+			if (hooks.getValue().getTarget().equals(uuid)){
+				count++;
+			}
+		}
+		setspeed(player, count);
+		player.getWorld().playSound(player.getLocation(), Sound.BLOCK_WOOD_BUTTON_CLICK_ON, 1F, .3F);
+		player.getWorld().spawnParticle(Particle.VILLAGER_ANGRY, player.getLocation().add(0, 1, 0), 1);
+		player.getWorld().spawnParticle(Particle.SPELL_WITCH, player.getLocation().add(0, 1, 0), 20);
+	}
+	
+	private void setspeed(Player p, int count) {
+		if (count <=0){
+			p.setWalkSpeed(0.2F);
+			held.remove(p.getUniqueId());
+		} else if (count >= effect.stopcount){
+			p.setWalkSpeed(0.0F);
+			held.add(p.getUniqueId());
+		} else {
+			double slowby = (effect.speed_change*count);
+			if (slowby < -0.2D)
+				slowby = -0.2D;
+			else if (slowby >= 0D)
+				slowby = 0D;
+			
+			if (slowby != 0D){
+				p.setWalkSpeed((float)(0.2D+slowby));
+			}
+			held.remove(p.getUniqueId());
+		}
+	}
+
+}

--- a/src/main/java/com/github/maxopoly/WurstCivTools/listener/ToolListener.java
+++ b/src/main/java/com/github/maxopoly/WurstCivTools/listener/ToolListener.java
@@ -1,6 +1,6 @@
 package com.github.maxopoly.WurstCivTools.listener;
 
-import java.util.LinkedList;
+import java.util.HashSet;
 import java.util.List;
 
 import org.bukkit.entity.EntityType;
@@ -11,7 +11,9 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.player.PlayerSwapHandItemsEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerItemHeldEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.projectiles.ProjectileSource;
 
@@ -26,7 +28,7 @@ public class ToolListener implements Listener {
 		this.manager = WurstCivTools.getManager();
 	}
 
-	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
 	public void blockBreak(BlockBreakEvent e) {
 		ItemStack is = e.getPlayer().getItemInHand();
 		for (Tag tag : getTags(is)) {
@@ -34,7 +36,7 @@ public class ToolListener implements Listener {
 		}
 	}
 
-	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
 	public void damageEntity(EntityDamageByEntityEvent e) {
 		Player p;
 		if (e.getDamager().getType() != EntityType.PLAYER) {
@@ -61,16 +63,40 @@ public class ToolListener implements Listener {
 		}
 	}
 
-	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
 	public void interact(PlayerInteractEvent e) {
-		ItemStack is = e.getItem();
-		for (Tag tag : getTags(is)) {
+		for (Tag tag : getTags(e.getItem())) {
 			tag.getEffect().handleInteract(e.getPlayer(), e);
 		}
 	}
+	
+	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+	public void itemSelect(PlayerItemHeldEvent e){
+		Player p = e.getPlayer();
+		ItemStack olditem = p.getInventory().getItem(e.getPreviousSlot());
+		for (Tag tag : getTags(olditem)){
+			tag.getEffect().handleItemDeselect(p, e);
+		}
+		
+		ItemStack newitem = p.getInventory().getItem(e.getNewSlot());
+		for (Tag tag : getTags(newitem)){
+			tag.getEffect().handleItemSelect(p, e);
+		}
+	}
+	
+	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+	public void switchItemOffhand(PlayerSwapHandItemsEvent e){
+		for (Tag tag : getTags(e.getMainHandItem())){
+			tag.getEffect().handleSwapToMainHand(e.getPlayer(), e);
+		}
+		
+		for (Tag tag : getTags(e.getOffHandItem())){
+			tag.getEffect().handleSwapToOffHand(e.getPlayer(), e);
+		}
+	}
 
-	private List<Tag> getTags(ItemStack is) {
-		List<Tag> tags = new LinkedList<Tag>();
+	private HashSet<Tag> getTags(ItemStack is) {
+		HashSet<Tag> tags = new HashSet<Tag>();
 		if (is == null) {
 			return tags;
 		}

--- a/src/main/java/com/github/maxopoly/WurstCivTools/misc/HookData.java
+++ b/src/main/java/com/github/maxopoly/WurstCivTools/misc/HookData.java
@@ -1,0 +1,26 @@
+package com.github.maxopoly.WurstCivTools.misc;
+
+import java.util.UUID;
+
+public class HookData {
+	private final UUID source;
+	private UUID target;
+	
+	
+	public HookData(UUID source, UUID target) {
+		this.source = source;
+		this.target = target;
+	}
+	public UUID getSource() {
+		return source;
+	}
+	public UUID getTarget() {
+		return target;
+	}
+	public void setTarget(UUID target) {
+		this.target = target;
+	}
+	
+	
+
+}

--- a/src/main/java/com/github/maxopoly/WurstCivTools/tags/LoreTag.java
+++ b/src/main/java/com/github/maxopoly/WurstCivTools/tags/LoreTag.java
@@ -20,6 +20,8 @@ public class LoreTag extends Tag{
 		}
 		ItemMeta im = is.getItemMeta();
 		List <String> appliedLore = im.getLore();
+		if (appliedLore == null)
+			return false;
 		for(String s : appliedLore) {
 			if (s.equals(lore)) {
 				return true;


### PR DESCRIPTION
- Added Playerhook(aka Tether tool)
- Added the following methods to the WurstEffect class: handleItemSelect, handleItemDeselect, handleSwapToMainHand, handleSwapToOffHand, & getListener
- Added Effect enabled bukkit listeners
- Added effect enabling/disabling in config
- Added some helper methods
- Fixed npe in LoreTag

New configuration:
https://gist.github.com/suirad/167775004845c797c15ae691da292b2c

Give command for testing:
`/give @p fishing_rod 1 0 {display:{Name:"PlayerHook",Lore:["Hook & Slow Other Players"]}}`
