### PR TITLE
Added LeafShears tool and small fix

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -10,7 +10,9 @@ tech:
       material: COMPASS
   leafshears:
     type: LEAFSHEARS
-    clearCubeSize: 3
+    clear_cube_size: 3
+    cannot_bypass_message: "&cSome of leaves are reinforced and therefore cannot be broken. Please use another tool to break it."
+    durability_loss_chance: 0.1
     tag:
       type: LORE
       lore: Leaf Shears

--- a/config.yml
+++ b/config.yml
@@ -8,6 +8,13 @@ tech:
       type: LORE
       lore: Inactive and Upgrading Pylons
       material: COMPASS
+  leafshears:
+    type: LEAFSHEARS
+    clearCubeSize: 3
+    tag:
+      type: LORE
+      lore: Leaf Shears
+      material: SHEARS
 anvil:
   repairMaterials:
     emerald:

--- a/plugin.yml
+++ b/plugin.yml
@@ -2,7 +2,7 @@ name: WurstCivTools
 version: 1.0
 author: [Maxopoly]
 depend: [CivModCore]
-softdepend: [FactoryMod]
+softdepend: [Citadel,FactoryMod]
 main: com.github.maxopoly.WurstCivTools.WurstCivTools
 commands:
 permissions:

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.github.maxopoly</groupId>
 	<artifactId>WurstCivTools</artifactId>
-	<version>1.1.6</version>
+	<version>1.1.7</version>
 	<packaging>jar</packaging>
 	<url>https://github.com/Civcraft/WurstCivTools</url>
 
@@ -39,7 +39,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.spigotmc</groupId>
-			<artifactId>spigot-api</artifactId>
+			<artifactId>spigot</artifactId>
 			<version>1.10-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.github.maxopoly</groupId>
 	<artifactId>WurstCivTools</artifactId>
-	<version>1.1.5</version>
+	<version>1.1.6</version>
 	<packaging>jar</packaging>
 	<url>https://github.com/Civcraft/WurstCivTools</url>
 
@@ -53,6 +53,12 @@
 			<groupId>com.github.igotyou</groupId>
 			<artifactId>FactoryMod</artifactId>
 			<version>2.2.0</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>vg.civcraft.mc.citadel</groupId>
+			<artifactId>Citadel</artifactId>
+			<version>3.5.4</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/com/github/maxopoly/WurstCivTools/ConfigParser.java
+++ b/src/main/java/com/github/maxopoly/WurstCivTools/ConfigParser.java
@@ -74,9 +74,13 @@ public class ConfigParser {
 					plugin.severe("Attempted to load LeafShears tool, but Citadel is not installed on this server");
 					continue;
 				}
-				int clearCubeSize = current.getInt("clearCubeSize", 3);
-				effect = new LeafShears(clearCubeSize);
-				plugin.info("Parsed LeafShears tool, clearCubeSize:" + clearCubeSize);
+				int clearCubeSize = current.getInt("clear_cube_size", 3);
+				String cannotBypassMessage = current.getString("cannot_bypass_message", "");
+				double durabilityLossChance = current.getDouble("durability_loss_chance", 0);
+				effect = new LeafShears(clearCubeSize, cannotBypassMessage, durabilityLossChance);
+				plugin.info("Parsed LeafShears tool, clearCubeSize:" + clearCubeSize
+						+ ", cannotBypassmessage: \"" + cannotBypassMessage + "\""
+						+ ", durabilityLossChance: " + durabilityLossChance);
 				break;
 			default:
 				plugin.severe("Could not identify effect type " + type + " at "

--- a/src/main/java/com/github/maxopoly/WurstCivTools/ConfigParser.java
+++ b/src/main/java/com/github/maxopoly/WurstCivTools/ConfigParser.java
@@ -1,13 +1,11 @@
 package com.github.maxopoly.WurstCivTools;
 
-import static vg.civcraft.mc.civmodcore.util.ConfigParsing.parseItemMap;
 import static vg.civcraft.mc.civmodcore.util.ConfigParsing.parseItemMapDirectly;
 import static vg.civcraft.mc.civmodcore.util.ConfigParsing.parseTime;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -15,10 +13,10 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.enchantments.Enchantment;
 
-import vg.civcraft.mc.civmodcore.Config;
 import vg.civcraft.mc.civmodcore.itemHandling.ItemMap;
 
 import com.github.maxopoly.WurstCivTools.anvil.AnvilHandler;
+import com.github.maxopoly.WurstCivTools.effect.LeafShears;
 import com.github.maxopoly.WurstCivTools.effect.PylonFinder;
 import com.github.maxopoly.WurstCivTools.effect.WurstEffect;
 import com.github.maxopoly.WurstCivTools.tags.LoreTag;
@@ -70,6 +68,15 @@ public class ConfigParser {
 				plugin.info("Parsed Pylonfinder tool, show_non_running:"
 						+ showNonRunning + ", showUpgrading:" + showUpgrading
 						+ ", cooldown:" + cd);
+				break;
+			case "LEAFSHEARS":
+				if (!Bukkit.getPluginManager().isPluginEnabled("Citadel")) {
+					plugin.severe("Attempted to load LeafShears tool, but Citadel is not installed on this server");
+					continue;
+				}
+				int clearCubeSize = current.getInt("clearCubeSize", 3);
+				effect = new LeafShears(clearCubeSize);
+				plugin.info("Parsed LeafShears tool, clearCubeSize:" + clearCubeSize);
 				break;
 			default:
 				plugin.severe("Could not identify effect type " + type + " at "

--- a/src/main/java/com/github/maxopoly/WurstCivTools/WurstCivTools.java
+++ b/src/main/java/com/github/maxopoly/WurstCivTools/WurstCivTools.java
@@ -2,17 +2,23 @@ package com.github.maxopoly.WurstCivTools;
 
 import org.bukkit.Bukkit;
 
+import vg.civcraft.mc.civmodcore.ACivMod;
+
 import com.github.maxopoly.WurstCivTools.anvil.AnvilHandler;
 import com.github.maxopoly.WurstCivTools.listener.AnvilListener;
 import com.github.maxopoly.WurstCivTools.listener.ToolListener;
-
-import vg.civcraft.mc.civmodcore.ACivMod;
+import com.github.maxopoly.WurstCivTools.nms.INmsManager;
 
 public class WurstCivTools extends ACivMod {
 	
 	private static WurstCivTools instance;
 	private static WurstManager manager;
 	private static AnvilHandler anvilHandler;
+	
+	private static INmsManager nmsManager;
+	public static INmsManager getNmsManager() {
+		return nmsManager;
+	}
 	
 	public String getPluginName() {
 		return "WurstCivTools";
@@ -23,6 +29,7 @@ public class WurstCivTools extends ACivMod {
 		ConfigParser cp = new ConfigParser();
 		manager = cp.parse();
 		anvilHandler = cp.getAnvilHandler();
+		nmsManager = new com.github.maxopoly.WurstCivTools.nms.v1_10_R1.NmsManager();
 		registerListeners();
 	}
 	

--- a/src/main/java/com/github/maxopoly/WurstCivTools/WurstManager.java
+++ b/src/main/java/com/github/maxopoly/WurstCivTools/WurstManager.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 
 import com.github.maxopoly.WurstCivTools.tags.Tag;

--- a/src/main/java/com/github/maxopoly/WurstCivTools/effect/LeafShears.java
+++ b/src/main/java/com/github/maxopoly/WurstCivTools/effect/LeafShears.java
@@ -1,0 +1,118 @@
+/**
+ * @author Aleksey Terzi
+ *
+ */
+
+package com.github.maxopoly.WurstCivTools.effect;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
+
+import vg.civcraft.mc.citadel.Citadel;
+import vg.civcraft.mc.citadel.PlayerState;
+import vg.civcraft.mc.citadel.reinforcement.PlayerReinforcement;
+import vg.civcraft.mc.citadel.reinforcement.Reinforcement;
+
+import com.github.maxopoly.WurstCivTools.WurstCivTools;
+
+public class LeafShears extends WurstEffect {
+	private int clearCubeSize;
+
+	public LeafShears(int clearCubeSize) {
+		super();
+		
+		this.clearCubeSize = clearCubeSize;
+	}
+
+	@Override
+	public void handleBreak(Player p, BlockBreakEvent e) {
+		if(e.isCancelled()) {
+			return;
+		}
+		
+		final Player player = p;
+		
+		if(player == null) {
+			return;
+		}
+		
+		if(!isLeaf(e.getBlock())) {
+			return;
+		}
+		
+		e.setCancelled(true);
+		e.getBlock().setType(Material.AIR);
+		
+		//Following manipulations are needed to synchronize tool durability with client after cancel block break
+		final ItemStack handItem = player.getInventory().getItemInMainHand();
+
+		handItem.setDurability((short)(handItem.getDurability() + 1));
+		
+		final Location center = e.getBlock().getLocation();
+		
+		Bukkit.getScheduler().runTask(WurstCivTools.getPlugin(), new Runnable() {
+            public void run() {
+            	handItem.setDurability((short)(handItem.getDurability() - 1));
+            	
+           		clearCube(player, center);
+            }
+        });
+	}
+	
+	private void clearCube(Player player, Location center) {
+		if(this.clearCubeSize <= 1) {
+			return;
+		}
+		
+		World world = center.getWorld();
+		int radius = (this.clearCubeSize - 1) / 2;
+		int startX = center.getBlockX() - radius;
+		int startY = center.getBlockY() - radius;
+		int startZ = center.getBlockZ() - radius;
+		PlayerState state = PlayerState.get(player);
+		boolean isBypassMode = state.isBypassMode();
+		
+		for(int x = startX; x < startX + this.clearCubeSize; x++) {
+			for(int y = startY; y < startY + this.clearCubeSize; y++) {
+				for(int z = startY; z < startZ + this.clearCubeSize; z++) {
+					if(x == center.getBlockX() && y == center.getBlockY() && z == center.getBlockZ()) {
+						continue;
+					}
+					
+					Block block = world.getBlockAt(x, y, z);
+					
+					if(!isLeaf(block) || !canBypass(player, isBypassMode, block.getLocation())) {
+						continue;
+					}
+					
+					block.setType(Material.AIR);
+				}
+			}
+		}
+	}
+	
+	private static boolean canBypass(Player player, boolean isBypassMode, Location loc) {
+		Reinforcement rein = Citadel.getReinforcementManager().getReinforcement(loc);
+		
+		if(rein == null || !(rein instanceof PlayerReinforcement)) return true;
+		
+		if(!isBypassMode) return false;
+		
+		PlayerReinforcement playerRein = (PlayerReinforcement)rein;
+		
+		return playerRein.canBypass(player)
+			|| player.hasPermission("citadel.admin.bypassmode");
+	}
+	
+	private static boolean isLeaf(Block block) {
+		Material blockMaterial = block.getType(); 
+		
+		return blockMaterial.equals(Material.LEAVES) || blockMaterial.equals(Material.LEAVES_2);
+	}
+}

--- a/src/main/java/com/github/maxopoly/WurstCivTools/effect/LeafShears.java
+++ b/src/main/java/com/github/maxopoly/WurstCivTools/effect/LeafShears.java
@@ -31,7 +31,7 @@ public class LeafShears extends WurstEffect {
 		super();
 		
 		this.clearCubeSize = clearCubeSize;
-	    this.cannotBypassMessage = ChatColor.translateAlternateColorCodes('&', cannotBypassMessage) + ChatColor.RED.getChar();
+	    this.cannotBypassMessage = ChatColor.translateAlternateColorCodes('&', cannotBypassMessage);
 	    this.durabilityLossChance = durabilityLossChance;
 	    this.rnd = new Random();
 	}

--- a/src/main/java/com/github/maxopoly/WurstCivTools/listener/ToolListener.java
+++ b/src/main/java/com/github/maxopoly/WurstCivTools/listener/ToolListener.java
@@ -28,7 +28,7 @@ public class ToolListener implements Listener {
 
 	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
 	public void blockBreak(BlockBreakEvent e) {
-		ItemStack is = e.getPlayer().getItemInHand();
+		ItemStack is = e.getPlayer().getInventory().getItemInMainHand();
 		for (Tag tag : getTags(is)) {
 			tag.getEffect().handleBreak(e.getPlayer(), e);
 		}
@@ -55,7 +55,7 @@ public class ToolListener implements Listener {
 		} else {
 			p = (Player) e.getDamager();
 		}
-		ItemStack is = p.getItemInHand();
+		ItemStack is = p.getInventory().getItemInMainHand();
 		for (Tag tag : getTags(is)) {
 			tag.getEffect().handleDamageEntity(p, e);
 		}

--- a/src/main/java/com/github/maxopoly/WurstCivTools/misc/ReflectionHelper.java
+++ b/src/main/java/com/github/maxopoly/WurstCivTools/misc/ReflectionHelper.java
@@ -1,0 +1,31 @@
+package com.github.maxopoly.WurstCivTools.misc;
+
+import java.lang.reflect.Field;
+
+public class ReflectionHelper {
+	public static Object getFieldValue(Object obj, String fieldName) {
+		Field field;
+		
+		try {
+			field = obj.getClass().getDeclaredField(fieldName);
+		} catch (NoSuchFieldException e) {
+			e.printStackTrace();
+			return null;
+		} catch (SecurityException e) {
+			e.printStackTrace();
+			return null;
+		}
+		
+		field.setAccessible(true);
+		
+		try {
+			return field.get(obj);
+		} catch (IllegalArgumentException e) {
+			e.printStackTrace();
+		} catch (IllegalAccessException e) {
+			e.printStackTrace();
+		}
+		
+		return null;
+	}
+}

--- a/src/main/java/com/github/maxopoly/WurstCivTools/nms/INmsManager.java
+++ b/src/main/java/com/github/maxopoly/WurstCivTools/nms/INmsManager.java
@@ -1,0 +1,8 @@
+package com.github.maxopoly.WurstCivTools.nms;
+
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+public interface INmsManager {
+	boolean damageItem(ItemStack item, int damage, Player player);
+}

--- a/src/main/java/com/github/maxopoly/WurstCivTools/nms/v1_10_R1/NmsManager.java
+++ b/src/main/java/com/github/maxopoly/WurstCivTools/nms/v1_10_R1/NmsManager.java
@@ -1,0 +1,22 @@
+package com.github.maxopoly.WurstCivTools.nms.v1_10_R1;
+
+import net.minecraft.server.v1_10_R1.EntityPlayer;
+import net.minecraft.server.v1_10_R1.ItemStack;
+
+import org.bukkit.craftbukkit.v1_10_R1.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_10_R1.inventory.CraftItemStack;
+import org.bukkit.entity.Player;
+
+import com.github.maxopoly.WurstCivTools.misc.ReflectionHelper;
+import com.github.maxopoly.WurstCivTools.nms.INmsManager;
+
+public class NmsManager implements INmsManager {
+	public boolean damageItem(org.bukkit.inventory.ItemStack item, int damage, Player player) {
+		EntityPlayer nmsPlayer = ((CraftPlayer)player).getHandle();
+		ItemStack nmsItem = (ItemStack)ReflectionHelper.getFieldValue((CraftItemStack)item, "handle");
+		
+		nmsItem.damage(damage, nmsPlayer);
+		
+		return nmsItem.count == 0;
+	}
+}

--- a/src/main/java/com/github/maxopoly/WurstCivTools/tags/LoreTag.java
+++ b/src/main/java/com/github/maxopoly/WurstCivTools/tags/LoreTag.java
@@ -1,6 +1,7 @@
 package com.github.maxopoly.WurstCivTools.tags;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
@@ -18,13 +19,18 @@ public class LoreTag extends Tag{
 		if (is == null) {
 			return false;
 		}
+		
 		ItemMeta im = is.getItemMeta();
-		List <String> appliedLore = im.getLore();
-		for(String s : appliedLore) {
-			if (s.equals(lore)) {
-				return true;
+		List<String> appliedLore = im.getLore();
+		
+		if(appliedLore != null) {
+			for(String s : appliedLore) {
+				if (Objects.equals(s, lore)) {
+					return true;
+				}
 			}
 		}
+		
 		return false;
 	}
 }


### PR DESCRIPTION
1) Added LeafShears which allows to clear leaves fast and without loosing durability on this special shears when breaking leaves. Default 'clear cube' has size 3 x 3 x 3. Could be configured.
New tool is requiring Citadel plugin.

2) Fixed error in LoreTag.appliedOn method when item's lore = null
