### PR TITLE
Proposed Cheaper Base Repair Costs (For Now)

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -30,58 +30,58 @@ anvil:
   materialCosts:
     diamondPick:
       material: DIAMOND_PICKAXE
-      value: 15
+      value: 5
     diamondSword:
       material: DIAMOND_SWORD
-      value: 10
+      value: 5
     diamondShovel:
       material: DIAMOND_SPADE
       value: 5
     diamondAxe:
       material: DIAMOND_AXE
-      value: 15
+      value: 5
     diamondHoe:
       material: DIAMOND_HOE
-      value: 10
+      value: 5
     diamondHelmet:
       material: DIAMOND_HELMET
-      value: 25
+      value: 5
     diamondChest:
       material: DIAMOND_CHESTPLATE
-      value: 40
+      value: 10
     diamondLeggings:
       material: DIAMOND_LEGGINGS
-      value: 35
+      value: 10
     diamondBoots:
       material: DIAMOND_BOOTS
-      value: 20
+      value: 5
     ironPick:
       material: IRON_PICKAXE
-      value: 6
+      value: 3
     ironSword:
       material: IRON_SWORD
-      value: 4
+      value: 3
     ironShovel:
       material: IRON_SPADE
-      value: 2
+      value: 3
     ironAxe:
       material: IRON_AXE
-      value: 6
+      value: 3
     ironHoe:
       material: IRON_HOE
-      value: 4
+      value: 3
     ironHelmet:
       material: IRON_HELMET
-      value: 10
+      value: 3
     ironChest:
       material: IRON_CHESTPLATE
-      value: 16
+      value: 6
     ironLeggings:
       material: IRON_LEGGINGS
-      value: 14
+      value: 6
     ironBoots:
       material: IRON_BOOTS
-      value: 8
+      value: 3
   enchantCosts:
         fireprot:
           enchant: PROTECTION_FIRE


### PR DESCRIPTION
As discussed, the changes were only really to make repairing un-enchanted diamond tools not insanely cheap. Having the cost also scale with how many diamonds it cost kind of made sense, but having a flat cost aside from Leggings and Chestplate works when the enchantments should make the main difference.

If we kept it the same as before, then repairing a Eff5Ub3 or ProtIVUb3 Chestplate would be twice as expensive, and as agreed that is far out from our original balance in line with how much a city will be making. This makes it so that repairing anything isn't completely free, while still making it so that the enchantments make up the majority of the cost increase.
